### PR TITLE
Feature/formatearRut

### DIFF
--- a/customErrors/cerrors.go
+++ b/customErrors/cerrors.go
@@ -9,6 +9,10 @@ type InvalidInputError struct {
 	Input string
 }
 
+type InvalidOptionError struct {
+	Input string
+}
+
 // Implement the Error method to satisfy the error interface.
 func (e *EmptyInputError) Error() string {
 	return "El string no puede estar vacio."
@@ -16,4 +20,8 @@ func (e *EmptyInputError) Error() string {
 
 func (e *InvalidInputError) Error() string {
 	return fmt.Sprintf("El input ('%s') solo debe contener numeros.", e.Input)
+}
+
+func (e *InvalidOptionError) Error() string {
+	return fmt.Sprintf("La opcion %s es invalida.", e.Input)
 }

--- a/rutificador.go
+++ b/rutificador.go
@@ -14,7 +14,7 @@ var multiplicador = [9]int{2, 3, 4, 5, 6, 7, 2, 3, 4}
 
 // Genera el digito verificador de un rut, a partir de un string con los numeros requeridos, los cuales pueden estar o no separados por puntos.
 func ObtenerDV(rut string) (dv rune, err error) {
-	rut = strings.ReplaceAll(strings.ReplaceAll(rut, ".", ""), "-", "")
+	rut = formatSinPuntosSinGuion(rut)
 	if len(rut) == 0 {
 		return '0', &customerrors.EmptyInputError{}
 	}
@@ -78,4 +78,44 @@ func GenerarRut(min, max int) string {
 
 func GenerarRutRandom() string {
 	return GenerarRut(4000000, 99999999)
+}
+
+func FormatearRut(rut string, formatOption int) (rutFormated string, err error) {
+	rut = strings.TrimSpace(rut)
+	switch formatOption {
+	case 1:
+		return formatPuntosGuion(rut), nil
+	case 2:
+		return formatSinPuntosConGuion(rut), nil
+	case 3:
+		return formatSinPuntosSinGuion(rut), nil
+	default:
+		return rut, &customerrors.InvalidOptionError{}
+	}
+
+}
+
+func formatPuntosGuion(rut string) string {
+	rut = formatSinPuntosSinGuion(rut)
+	lastDigit := rut[len(rut)-1]
+	rut = rut[0 : len(rut)-1]
+	rut = utils.Reverse(rut)
+	newRut := ""
+	for i, t := range rut {
+		if i > 0 && i%3 == 0 {
+			newRut = fmt.Sprintf("%s.%s", newRut, string(t))
+		} else {
+			newRut = fmt.Sprintf("%s%s", newRut, string(t))
+		}
+	}
+
+	return fmt.Sprintf("%s-%s", utils.Reverse(newRut), string(lastDigit))
+}
+
+func formatSinPuntosConGuion(rut string) string {
+	return strings.ReplaceAll(rut, ".", "")
+}
+
+func formatSinPuntosSinGuion(rut string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(rut, ".", ""), "-", "")
 }

--- a/rutificador_test.go
+++ b/rutificador_test.go
@@ -100,3 +100,44 @@ func TestGenerarRut(t *testing.T) {
 		}
 	}
 }
+
+func TestFormatPuntosGuion(t *testing.T) {
+	testCases := []struct {
+		rut      string
+		formated string
+	}{
+		{rut: "18622178-8", formated: "18.622.178-8"},
+		{rut: "11111111-1", formated: "11.111.111-1"},
+		{rut: "8000000-8", formated: "8.000.000-8"},
+	}
+	for _, tc := range testCases {
+		if result := formatPuntosGuion(tc.rut); result != tc.formated {
+			t.Errorf("formatPuntosGuion(%s) = %s; want: %s", tc.rut, result, tc.formated)
+		}
+	}
+}
+
+func TestFormatearRut(t *testing.T) {
+	testCases := []struct {
+		rut      string
+		option   int
+		formated string
+		err      error
+	}{
+		{rut: "18622178-8", option: 1, formated: "18.622.178-8", err: nil},
+		{rut: "11111111-1", option: 1, formated: "11.111.111-1", err: nil},
+		{rut: "8000000-8", option: 1, formated: "8.000.000-8", err: nil},
+		{rut: "18.622.178-8", option: 2, formated: "18622178-8", err: nil},
+		{rut: "11.111.111-1", option: 2, formated: "11111111-1", err: nil},
+		{rut: "8.000.000-8", option: 2, formated: "8000000-8", err: nil},
+		{rut: "18.622.178-8", option: 3, formated: "186221788", err: nil},
+		{rut: "11.111.111-1", option: 3, formated: "111111111", err: nil},
+		{rut: "8.000.000-8", option: 3, formated: "80000008", err: nil},
+		{rut: "18622178-8", option: 23, formated: "18622178-8", err: &customerrors.InvalidOptionError{}},
+	}
+	for _, tc := range testCases {
+		if result, err := FormatearRut(tc.rut, tc.option); result != tc.formated || tc.err != nil && err == tc.err {
+			t.Errorf("formatPuntosGuion(%s, %d) = %s; want: %s; error wanted: %s", tc.rut, tc.option, result, tc.formated, tc.err)
+		}
+	}
+}


### PR DESCRIPTION
Se agrega funcionalidad para formatear un rut con la funcion FormatearRut
El uso es el siguiente:
rutificagor.FormatearRut("111111111", 1) -> "11.111.111-1"
Las opciones son:
- 1: Agregar puntos y guion
- 2: Sacar puntos, dejar guion
- 3: Sacar puntos y guion